### PR TITLE
ability to view existing feedback on the frontend

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -6,6 +6,20 @@ class FeedbacksController < ApplicationController
     redirect_to root_path
   end
 
+  def exists
+    # function that checks if the handle exists in the database
+    # then returns a json object with true
+
+    handle = params[:handle]
+    exists = Feedback.exists?(recipient_handle: handle)
+    if exists
+      feedback = Feedback.where(recipient_handle: handle).last
+      render json: {exists: true, existing_feedback_tweet_url: feedback.tweet_url}
+    else
+      render json: {exists: false}
+    end
+  end
+
   private
 
   def feedback_params

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -49,16 +49,57 @@
 <% end %>
 
 <script type="text/javascript">
-  const charCounter = document.getElementById('char_counter');
+  /*
+  if charCounter hasn't been declared yet, declare it
+  otherwise it will throw error when you refresh the page (i.e. send tweet)
+  */
+  if (typeof charCounter === 'undefined') {
+    const charCounter = document.getElementById('char_counter');
 
-  document.getElementById('text').addEventListener('keyup', function(){
-    let charLength = this.value.length;
-    charCounter.innerText = charLength;
+    document.getElementById('text').addEventListener('keyup', function(){
+      let charLength = this.value.length;
+      charCounter.innerText = charLength;
 
-    if (charLength == 250) {
-      charCounter.style.color = 'red';
-    } else {
-      charCounter.style.color = 'black'
-    }
-  });
+      if (charLength == 250) {
+        charCounter.style.color = 'red';
+      } else {
+        charCounter.style.color = 'black'
+      }
+    });
+  }
+
+  /* same logic applies to recipientHandle */
+
+  if (typeof recipientHandle === 'undefined') {
+    const recipientHandle = document.getElementById('feedback_recipient_handle');
+
+    /*
+    add event listener to feedback_recipient_handle on the change
+    that queries the ruby backend to see if that handle exists in database
+    */
+    recipientHandle.addEventListener('change', function() {
+      const handle = recipientHandle.value;
+      /* make a fetch request to the backend to see if the handle exists */
+      fetch('/feedbacks/exists?handle=' + handle)
+        .then(response => response.json())
+        .then(data => {
+          /* if existing_feedback_tweet_url is not null, create new paragraph in html
+          with link to existing feedback tweet
+          otherwise delete that paragraph if exists */
+          if (data.existing_feedback_tweet_url) {
+            const existingFeedbackTweetUrl = data.existing_feedback_tweet_url;
+            const existingFeedbackTweetUrlParagraph = document.createElement('div');
+            existingFeedbackTweetUrlParagraph.classList.add('mt-4');
+            existingFeedbackTweetUrlParagraph.innerHTML = `<p class="text-sm text-gray-500">We've already received feedback for this handle. <a href="${existingFeedbackTweetUrl}" target="_blank" class="text-indigo-600 hover:text-indigo-500">View it here</a>.</p>`;
+            recipientHandle.parentNode.parentNode.appendChild(existingFeedbackTweetUrlParagraph);
+          } else {
+            const existingFeedbackTweetUrlParagraph = recipientHandle.parentNode.parentNode.querySelector('div.mt-4');
+            if (existingFeedbackTweetUrlParagraph) {
+              existingFeedbackTweetUrlParagraph.remove();
+            }
+          }
+        });
+    });
+  }
+
 </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   # root "articles#index"
   root 'pages#home'
   post 'feedbacks', to: 'feedbacks#create'
+  get 'feedbacks/exists', to: 'feedbacks#exists'
 end


### PR DESCRIPTION
Addressing issue #7 

Potential discussion points:
- I noticed that once a tweet is sent (and the page refreshed after), the Chrome console throws an error that `charCounter` has already been defined and we are attempting to redefine it again (line https://github.com/founderhacker/unidentified_feedback/blob/main/app/views/pages/home.html.erb#L52). 
The workaround was to define the charCounter (together with the functionality of counting the number of characters of tweet inside this if statement `if (typeof charCounter === 'undefined')` but not sure if the best approach 